### PR TITLE
Attempt to make the generator more intuitive

### DIFF
--- a/src/main/scala/ipranges/v4/Gen.scala
+++ b/src/main/scala/ipranges/v4/Gen.scala
@@ -12,4 +12,47 @@ class Gen {
   }
 }
 
+object FakeIP{
+  def apply(
+             aS : String,
+             bS : String,
+             cS : String,
+             dS : String) :IP = {
+    val a = Random.nextInt & 255
+    val b = Random.nextInt & 255
+    val c = Random.nextInt & 255
+    val d = Random.nextInt & 255
+    IP(a << 24 | b << 16 | c << 8 | d)
+  }
+
+  def apply(
+             a : Int,
+             bS : String,
+             cS : String,
+             dS : String) :IP = {
+    val b = Random.nextInt & 255
+    val c = Random.nextInt & 255
+    val d = Random.nextInt & 255
+    IP(a << 24 | b << 16 | c << 8 | d)
+  }
+
+  def apply(
+             a : Int,
+             b : Int,
+             cS : String,
+             dS : String) :IP = {
+    val c = Random.nextInt & 255
+    val d = Random.nextInt & 255
+    IP(a << 24 | b << 16 | c << 8 | d)
+  }
+
+  def apply(
+             a : Int,
+             b : Int,
+             c : Int,
+             dS : String) :IP = {
+    val d = Random.nextInt & 255
+    IP(a << 24 | b << 16 | c << 8 | d)
+  }
+}
 


### PR DESCRIPTION
Simple/naive way to do it.
FakeIP(10,9,"x","x") will output be something looking like IP(10,9,1,2)

I plan to improve it this way:
FakeIP(10,9,"x","x") would output be something looking like IP(10,9,20,20)
FakeIP(10,9,"x","y") would output be something looking like IP(10,9,20,2)
